### PR TITLE
fix error on serialization of metric_fu yaml report of .erb files

### DIFF
--- a/src/main/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexityYamlParserImpl.java
+++ b/src/main/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexityYamlParserImpl.java
@@ -31,6 +31,10 @@ public class MetricfuComplexityYamlParserImpl implements MetricfuComplexityYamlP
             fileString = StringUtils.remove(fileString, stringToRemove);
         }
 
+        // change 'name: !binary' to 'name: tag:yaml.org,2002:binary'
+        // normally this !binary tags will be on the metric_fu analysis of .erb files as 'class_name: !binary' and 'name: !binary'
+        fileString = StringUtils.replace(fileString, "name: !binary", "name: tag:yaml.org,2002:binary");
+
         Yaml yaml = new Yaml();
 
         Map<String, Object> metricfuResult = (Map<String, Object>) yaml.loadAs(fileString, Map.class);

--- a/src/test/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexityYamlParserTest.java
+++ b/src/test/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexityYamlParserTest.java
@@ -10,7 +10,8 @@ import org.junit.Test;
 public class MetricfuComplexityYamlParserTest extends TestCase
 {
 	private final static String YML_FILE_NAME = "src/test/resources/test-data/results.yml";
-	
+	private final static String YML_FILE_NAME_WITH_BINARY_TAGS = "src/test/resources/test-data/results_with-binary-tag.yml";
+
 	private MetricfuComplexityYamlParserImpl parser = null;
 	
 	@Before
@@ -29,4 +30,15 @@ public class MetricfuComplexityYamlParserTest extends TestCase
 		assertTrue(rubyFunctions.size()==2);
 		assertTrue(rubyFunctions.get(0).toString().equals(rubyFunction0.toString()));
 	}	
+
+	@Test
+	public void testParseFunction_withReportWithBinaryTypes() throws IOException
+	{
+		File reportFile = new File(YML_FILE_NAME_WITH_BINARY_TAGS);
+		List<RubyFunction> rubyFunctions = parser.parseFunctions("lib/some_path/foo_bar.rb", reportFile);
+
+		RubyFunction rubyFunction0 = new RubyFunction("FooBar#validate_user_name", 10, 500);
+		assertTrue(rubyFunctions.size()==2);
+		assertTrue(rubyFunctions.get(0).toString().equals(rubyFunction0.toString()));
+	}
 }

--- a/src/test/resources/test-data/results_with-binary-tag.yml
+++ b/src/test/resources/test-data/results_with-binary-tag.yml
@@ -1,0 +1,51 @@
+---
+:saikuro:
+  :files:
+  - :classes:
+    - :class_name: FooBar
+      :complexity: 13
+      :lines: 36
+      :methods:
+      - :name: FooBar#validate_user_name
+        :complexity: 10
+        :lines: 500
+      - :name: FooBar#validate_password
+        :complexity: 3
+        :lines: 4
+    :filename: lib/some_path/foo_bar.rb
+  - :classes:
+    - :class_name: ''
+      :complexity: 0
+      :lines: 1
+      :methods: []
+    - :class_name: "::"
+      :complexity: 0
+      :lines: 2
+      :methods: []
+    - :class_name: !binary |-
+        Ojo6OkF0bMOibnRpY28=
+      :complexity: 0
+      :lines: 9
+      :methods: []
+    - :class_name: !binary |-
+        Ojo6OkF0bMOibnRpY286Og==
+      :complexity: 0
+      :lines: 1
+      :methods: []
+    - :class_name: !binary |-
+        Ojo6OkF0bMOibnRpY286Ojo6
+      :complexity: 0
+      :lines: 3
+      :methods: []
+    - :class_name: !binary |-
+        Ojo6OkF0bMOibnRpY286Ojo6Ojo=
+      :complexity: 0
+      :lines: 0
+      :methods: []
+    - :class_name: !binary |-
+        Ojo6OkF0bMOibnRpY286Ojo6Ojo6Og==
+      :complexity: 2
+      :lines: 9
+      :methods: []
+    :filename: app/views/shared/_header.html.erb
+:hotspots:


### PR DESCRIPTION
On Sonar Runner analysis of a Ruby project with .erb files, which
metric_fu puts in its report file the '!binary' type on the 'class_name'
and 'name' properties. The SnakeYAML library throws an error when
loading the yaml file string as a Map: see line 36 of
MetricfuComplexityYamlParserImpl class.

The fix is to replace, in the yaml file string, the string
'name: !binary' to the string 'name: tag:yaml.org,2002:binary'.
