### PR TITLE
measures not saved on sonar equal or greater than 4.4

### DIFF
--- a/src/main/java/com/godaddy/sonar/ruby/RubySensor.java
+++ b/src/main/java/com/godaddy/sonar/ruby/RubySensor.java
@@ -1,7 +1,6 @@
 package com.godaddy.sonar.ruby;
 
 import com.godaddy.sonar.ruby.core.Ruby;
-import com.godaddy.sonar.ruby.core.RubyFile;
 import com.godaddy.sonar.ruby.core.RubyPackage;
 import com.godaddy.sonar.ruby.core.RubyRecognizer;
 import com.godaddy.sonar.ruby.parsers.CommentCountParser;
@@ -22,7 +21,6 @@ import java.io.File;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class RubySensor implements Sensor
@@ -47,7 +45,6 @@ public class RubySensor implements Sensor
     protected void computeBaseMetrics(SensorContext sensorContext, Project project)
     {
         Reader reader = null;
-        List<File> sourceDirs = moduleFileSystem.sourceDirs();
 
         Set<RubyPackage> packageList = new HashSet<RubyPackage>();
         for (File rubyFile : moduleFileSystem.files(FileQuery.onSource().onLanguage(project.getLanguageKey())))
@@ -55,7 +52,7 @@ public class RubySensor implements Sensor
             try
             {
                 reader = new StringReader(FileUtils.readFileToString(rubyFile, moduleFileSystem.sourceCharset().name()));
-                RubyFile resource = new RubyFile(rubyFile, sourceDirs);
+                org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(rubyFile, project);
                 Source source = new Source(reader, new RubyRecognizer());
                 packageList.add(new RubyPackage(resource.getParent().getKey()));
 

--- a/src/main/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexitySensor.java
+++ b/src/main/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexitySensor.java
@@ -59,8 +59,9 @@ public class MetricfuComplexitySensor implements Sensor
 
     private void analyzeFile(File file, List<File> sourceDirs, SensorContext sensorContext, File resultsFile) throws IOException
     {
-        RubyFile resource = new RubyFile(file, sourceDirs);
-        List<RubyFunction> functions = metricfuComplexityYamlParser.parseFunctions(resource.getName(), resultsFile);
+        RubyFile rubyFile = new RubyFile(file, sourceDirs);
+        org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(file, sourceDirs);
+        List<RubyFunction> functions = metricfuComplexityYamlParser.parseFunctions(rubyFile.getName(), resultsFile);
 
         // if function list is empty, then return, do not compute any complexity
         // on that file

--- a/src/main/java/com/godaddy/sonar/ruby/simplecovrcov/SimpleCovRcovSensor.java
+++ b/src/main/java/com/godaddy/sonar/ruby/simplecovrcov/SimpleCovRcovSensor.java
@@ -15,7 +15,6 @@ import org.sonar.api.resources.Project;
 import org.sonar.api.scan.filesystem.ModuleFileSystem;
 
 import com.godaddy.sonar.ruby.core.Ruby;
-import com.godaddy.sonar.ruby.core.RubyFile;
 
 public class SimpleCovRcovSensor implements Sensor 
 {
@@ -65,14 +64,14 @@ public class SimpleCovRcovSensor implements Sensor
             {
                 String fileName = entry.getKey();
                 sourceFile = new File(fileName);
-                RubyFile rubyFile = new RubyFile(sourceFile, sourceDirs);
+                org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(sourceFile, sourceDirs);
 
                 CoverageMeasuresBuilder fileCoverage = entry.getValue();
                 if (fileCoverage != null) 
                 {
                     for (Measure measure : fileCoverage.createMeasures()) 
                     {
-                        context.saveMeasure(rubyFile, measure);
+                        context.saveMeasure(resource, measure);
                     }
                 }
             } 

--- a/src/test/java/com/godaddy/sonar/ruby/RubySensorTest.java
+++ b/src/test/java/com/godaddy/sonar/ruby/RubySensorTest.java
@@ -19,18 +19,20 @@ import org.sonar.api.batch.SensorContext;
 import org.sonar.api.measures.Measure;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.resources.Project;
+import org.sonar.api.resources.ProjectFileSystem;
 import org.sonar.api.scan.filesystem.FileQuery;
 import org.sonar.api.scan.filesystem.ModuleFileSystem;
 
-import com.godaddy.sonar.ruby.core.RubyFile;
 import com.godaddy.sonar.ruby.core.RubyPackage;
 
+@SuppressWarnings("deprecation")
 public class RubySensorTest {
 	public static String INPUT_SOURCE_DIR = "src/test/resources/test-data";
 	public static String INPUT_SOURCE_FILE = "src/test/resources/test-data/hello_world.rb";
 
 	private IMocksControl mocksControl;
 	private ModuleFileSystem moduleFileSystem;
+	private ProjectFileSystem projectFileSystem;
 	private SensorContext sensorContext;
 	private Configuration config;
 	private Project project;
@@ -41,12 +43,14 @@ public class RubySensorTest {
 	public void setUp() throws Exception {
 		mocksControl = EasyMock.createControl();
 		moduleFileSystem = mocksControl.createMock(ModuleFileSystem.class);
+		projectFileSystem = mocksControl.createMock(ProjectFileSystem.class);
 
 		config = mocksControl.createMock(Configuration.class);
 		expect(config.getString("sonar.language", "java")).andStubReturn("ruby");
 
 		project = new Project("test project");
 		project.setConfiguration(config);
+		project.setFileSystem(projectFileSystem);
 
 		sensorContext = mocksControl.createMock(SensorContext.class);
 
@@ -84,9 +88,9 @@ public class RubySensorTest {
 		Measure measure = new Measure();
 		
 		expect(moduleFileSystem.files(isA(FileQuery.class))).andReturn(files).once();
-		expect(moduleFileSystem.sourceDirs()).andReturn(sourceDirs).once();
+		expect(projectFileSystem.getSourceDirs()).andReturn(sourceDirs).once();
 		expect(moduleFileSystem.sourceCharset()).andReturn(Charset.defaultCharset()).once();
-		expect(sensorContext.saveMeasure(isA(RubyFile.class), isA(Metric.class), isA(Double.class))).andReturn(measure).times(5);
+		expect(sensorContext.saveMeasure(isA(org.sonar.api.resources.File.class), isA(Metric.class), isA(Double.class))).andReturn(measure).times(5);
 		expect(sensorContext.saveMeasure(isA(RubyPackage.class), isA(Metric.class), isA(Double.class))).andReturn(measure).times(1);
 
 		mocksControl.replay();

--- a/src/test/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexitySensorTest.java
+++ b/src/test/java/com/godaddy/sonar/ruby/metricfu/MetricfuComplexitySensorTest.java
@@ -20,7 +20,6 @@ import org.sonar.api.scan.filesystem.FileQuery;
 import org.sonar.api.scan.filesystem.ModuleFileSystem;
 
 import com.godaddy.sonar.ruby.RubySensor;
-import com.godaddy.sonar.ruby.core.RubyFile;
 
 
 public class MetricfuComplexitySensorTest 
@@ -89,9 +88,9 @@ public class MetricfuComplexitySensorTest
 		expect(moduleFileSystem.files(isA(FileQuery.class))).andReturn(sourceFiles);
 		expect(moduleFileSystem.sourceDirs()).andReturn(sourceDirs);
 		expect(metricfuComplexityYamlParser.parseFunctions(isA(String.class),isA(File.class))).andReturn(functions);
-		expect(sensorContext.saveMeasure(isA(RubyFile.class), isA(Metric.class), isA(Double.class))).andReturn(measure).times(2);
-		expect(sensorContext.saveMeasure(isA(RubyFile.class), isA(Measure.class))).andReturn(measure).times(2);
-		
+		expect(sensorContext.saveMeasure(isA(org.sonar.api.resources.File.class), isA(Metric.class), isA(Double.class))).andReturn(measure).times(2);
+		expect(sensorContext.saveMeasure(isA(org.sonar.api.resources.File.class), isA(Measure.class))).andReturn(measure).times(2);
+
 		mocksControl.replay();
 
 		metricfuComplexitySensor.analyse(project, sensorContext);

--- a/src/test/java/com/godaddy/sonar/ruby/simplecovrcov/SimpleCovRcovSensorTest.java
+++ b/src/test/java/com/godaddy/sonar/ruby/simplecovrcov/SimpleCovRcovSensorTest.java
@@ -20,7 +20,6 @@ import org.sonar.api.measures.Measure;
 import org.sonar.api.resources.Project;
 import org.sonar.api.scan.filesystem.ModuleFileSystem;
 
-import com.godaddy.sonar.ruby.core.RubyFile;
 
 public class SimpleCovRcovSensorTest 
 {
@@ -108,7 +107,7 @@ public class SimpleCovRcovSensorTest
 		List<File> sourceDirs = new ArrayList<File>();	
 		for (String fileName : jsonResults.keySet())
 		{
-			sourceDirs.add(new File(fileName));
+			sourceDirs.add(new File(fileName).getParentFile());
 		}
 		
 		Measure measure = new Measure();		
@@ -116,8 +115,8 @@ public class SimpleCovRcovSensorTest
 		
 		expect(moduleFileSystem.sourceDirs()).andReturn(sourceDirs).once();
 		expect(simpleCovRcovJsonParser.parse(eq(new File("coverage/.resultset.json")))).andReturn(jsonResults).once();
-		expect(sensorContext.saveMeasure(isA(RubyFile.class), isA(Measure.class))).andReturn(measure).times(9);
-	
+		expect(sensorContext.saveMeasure(isA(org.sonar.api.resources.File.class), isA(Measure.class))).andReturn(measure).times(9);
+
 		mocksControl.replay();
 
 		simpleCovRcovSensor.analyse(new Project("key_name"), sensorContext);
@@ -133,7 +132,7 @@ public class SimpleCovRcovSensorTest
 		List<File> sourceDirs = new ArrayList<File>();	
 		for (String fileName : jsonResults.keySet())
 		{
-			sourceDirs.add(new File(fileName));
+			sourceDirs.add(new File(fileName).getParentFile());
 		}
 		
 		Measure measure = new Measure();		
@@ -141,8 +140,8 @@ public class SimpleCovRcovSensorTest
 		
 		expect(moduleFileSystem.sourceDirs()).andReturn(sourceDirs).once();
 		expect(simpleCovRcovJsonParser.parse(eq(new File("coverage/.resultset.json")))).andReturn(jsonResults).once();
-		expect(sensorContext.saveMeasure(isA(RubyFile.class), isA(Measure.class))).andReturn(measure).times(36);
-	
+		expect(sensorContext.saveMeasure(isA(org.sonar.api.resources.File.class), isA(Measure.class))).andReturn(measure).times(36);
+
 		mocksControl.replay();
 
 		simpleCovRcovSensor.analyse(new Project("key_name"), sensorContext);


### PR DESCRIPTION
The measures of 'basic metrics' (ncloc, files, etc.), 'complexity'
and coverage are not saved on Sonar version equal or greater than
4.4 but the source files are saved. On Sonar 3.7.4 these metrics
measures are saved.

The fix is to use a org.sonar.api.resources.File as the resource
on the sensorContext.saveMeasure method. The idea came from
looking at the source of Javascript Sonar Plugin. With this the
measures are saved in Sonar 3.7.4 and Sonar 4.4 or greater.
